### PR TITLE
including typescript.tsx and javascript.jsx filetypes

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -62,7 +62,7 @@ M.is_supported = function (lang)
 end
 
 local function is_jsx()
-  return  is_in_table({'typescriptreact', 'javascriptreact', 'javascript', 'typescript'}, vim.bo.filetype)
+  return  is_in_table({'typescriptreact', 'javascriptreact', 'javascript.jsx', 'typescript.tsx', 'javascript', 'typescript'}, vim.bo.filetype)
 end
 
 local function get_ts_tag()


### PR DESCRIPTION
For some people (like me) `vim.bo.filetype` returns  `'typescript.tsx'` and `'javascript.jsx'`, making `is_jsx` to return `false`.

This PR fixes the issues on typescript mentioned in #10.