### PR TITLE
feat: added markdown support

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -10,6 +10,7 @@ M.tbl_filetypes = {
     'html', 'javascript', 'typescript', 'javascriptreact', 'typescriptreact', 'svelte', 'vue', 'tsx', 'jsx',
     'xml',
     'php',
+    'markdown',
     'glimmer','handlebars','hbs'
 }
 
@@ -21,7 +22,7 @@ M.tbl_skipTag = {
 local ERROR_TAG = "ERROR"
 
 local HTML_TAG = {
-    filetypes              = {'html', 'php', 'xml'},
+    filetypes              = {'html', 'php', 'xml', 'markdown'},
     start_tag_pattern      = 'start_tag',
     start_name_tag_pattern = 'tag_name',
     end_tag_pattern        = "end_tag",


### PR DESCRIPTION
Now that treesitter supports markdown officially, it is possible to use autotag for HTML tags in Markdown with this PR.