### PR TITLE
Update filetypes defaults in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ vim.lsp.handlers['textDocument/publishDiagnostics'] = vim.lsp.with(
 
 ``` lua
 local filetypes = {
-  'html', 'javascript', 'javascriptreact', 'typescriptreact', 'svelte', 'vue', 'rescript'
+    'html', 'javascript', 'typescript', 'javascriptreact', 'typescriptreact', 'svelte', 'vue', 'tsx', 'jsx', 'rescript',
+    'xml',
+    'php',
+    'markdown',
+    'glimmer','handlebars','hbs'
 }
 local skip_tags = {
   'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'slot',


### PR DESCRIPTION
Was noting the autotag was running in markdown but reading the README has no mention of this filetype. So adding this to clarify the defaults. 