### PR TITLE
Update internal.lua

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -394,7 +394,7 @@ local function validate_rename()
     local line   = vim.fn.getline(cursor[1])
     local char   = line:sub(cursor[2] + 1, cursor[2] + 1)
     -- only rename when last character is a word
-    if string.match(char,'%w') then
+    if string.match(char,'[%w.]') then
         return true
     end
     return false


### PR DESCRIPTION
Added dot to %w, so that tagname is also renamed when included dot.

Autotag does not work when changing from a tag without a dot to a tagname with a dot.

This may be inconvenient in some scenarios, such as `Context.Provider`, `React.Fragment`, etc.

Simple added . character for regular %w.

![ezgif-5-c8d1438371](https://user-images.githubusercontent.com/4456413/161638448-b6bf3f23-d3f0-45a2-99c5-2d0a25f4f649.gif)
