### PR TITLE
fix: ts_utils.get_node_text function deprecated

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -1,8 +1,7 @@
 local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
+local get_node_text = vim.treesitter.query.get_node_text
 local configs = require'nvim-treesitter.configs'
 local parsers = require'nvim-treesitter.parsers'
-local log = require('nvim-ts-autotag._log')
--- local utils=require('nvim-ts-autotag.utils')
 
 local M = {}
 
@@ -163,8 +162,8 @@ local function find_parent_match(opts)
 
 local function get_tag_name(node)
     local tag_name = nil
-    if node ~=nil then
-        tag_name = ts_utils.get_node_text(node)[1]
+    if node ~= nil then
+        tag_name = get_node_text(node, vim.api.nvim_get_current_buf())
     end
     return tag_name
 end
@@ -285,8 +284,8 @@ end
 
 
 local function validate_tag_regex(node,start_regex,end_regex)
-    if node == nil  then return false end
-    local texts = ts_utils.get_node_text(node)
+    if node == nil then return false end
+    local texts = get_node_text(node, vim.api.nvim_get_current_buf())
     if
         string.match(texts[1],start_regex)
         and string.match(texts[#texts],end_regex)


### PR DESCRIPTION
I received warning after upgrade nvim-treesitter.
![CleanShot 2022-04-21 at 14 29 53@2x](https://user-images.githubusercontent.com/10345518/164389306-880d51d0-1750-4e4c-8d6a-2df1503f8edb.png)

[nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/blob/6d0cee2f570ab848c0049be5a84a20acba3e8217/lua/nvim-treesitter/ts_utils.lua#L15) marked `ts_utils.get_node_text` as deprecated. In this PR, replace `ts_utils.get_node_text` with `vim.treesitter.query.get_node_text`


