### PR TITLE
Feat: Add heex support (html + embedded elixir).

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -11,7 +11,8 @@ M.tbl_filetypes = {
     'php',
     'markdown',
     'glimmer','handlebars','hbs',
-    'htmldjango'
+    'htmldjango',
+    'heex'
 }
 
 M.tbl_skipTag = {
@@ -74,10 +75,23 @@ local SVELTE_TAG = {
     skip_tag_pattern       = {'quoted_attribute_value', 'end_tag'},
 }
 
+local HEEX_TAG = {
+    filetypes              = {'heex'},
+    start_tag_pattern      = 'start_tag|start_component',
+    start_name_tag_pattern = 'tag_name|component_name',
+    end_tag_pattern        = "end_tag|end_component",
+    end_name_tag_pattern   = "tag_name|component_name",
+    close_tag_pattern      = 'erroneous_end_tag',
+    close_name_tag_pattern = 'erroneous_end_tag_name',
+    element_tag            = 'element',
+    skip_tag_pattern       = {'quoted_attribute_value', 'end_tag', 'end_component'}
+}
+
 local all_tag = {
     HBS_TAG,
     SVELTE_TAG,
-    JSX_TAG
+    JSX_TAG,
+    HEEX_TAG
 }
 M.enable_rename = true
 M.enable_close  = true
@@ -142,9 +156,9 @@ local function find_parent_match(opts)
     local skip_tag_pattern = opts.skip_tag_pattern
     assert(target ~= nil, "find parent target not nil :" .. pattern)
     local cur_depth = 0
-    local cur_node = target
     local tbl_pattern = vim.split(pattern, "|")
     for _,ptn in pairs(tbl_pattern) do
+        local cur_node = target
         while cur_node ~= nil do
             local node_type = cur_node:type()
             if is_in_table(skip_tag_pattern, node_type) then return nil end

--- a/sample/index.html.heex
+++ b/sample/index.html.heex
@@ -1,0 +1,12 @@
+<div class='dsfds'>
+  <h1><%= @title %></h1>
+  <.good></.good>
+  <.window></.window>
+</div>
+<div>
+
+
+
+
+
+</div>

--- a/tests/closetag_spec.lua
+++ b/tests/closetag_spec.lua
@@ -244,6 +244,15 @@ local data = {
     before   = [[<button onClick>{|}</button> ]],
     after    = [[<button onClick>{>|}</button> ]]
   },
+  {
+    name     = "24 heex div",
+    filepath = './sample/index.html.heex',
+    filetype = "heex",
+    linenr   = 9,
+    key      = [[>]],
+    before   = [[<div| ]],
+    after    = [[<div>|</div> ]]
+  }
 }
 local run_data = {}
 for _, value in pairs(data) do


### PR DESCRIPTION
This change adds support for the `heex` file type that is used for [Phoenix Framework](https://www.phoenixframework.org/) templates.

`heex` is like normal HTML but supports function and module components as well that get parsed into `start_component`, `end_component` and `component_name` nodes. 

As a result this changeset adds a new tag set for `heex` that uses alternations for the start node pattern, end node pattern and name patterns.

This change also fixes a bug in `find_parent_match` where `cur_node` was not being reset between matching iterations.