### PR TITLE
feat: js template tags

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -515,12 +515,13 @@ M.attach = function(bufnr, lang)
         end
         if M.enable_rename == true then
             bufnr = bufnr or vim.api.nvim_get_current_buf()
-            vim.cmd(
-                string.format(
-                    [[autocmd! InsertLeave <buffer=%s> call v:lua.require('nvim-ts-autotag.internal').rename_tag() ]],
-                    bufnr
-                )
-            )
+            vim.api.nvim_create_autocmd('InsertLeave', {
+              group = vim.api.nvim_create_augroup('ts-autotag-rename', { clear = true }),
+              buffer = bufnr,
+              callback = function()
+                M.rename_tag()
+              end
+            })
         end
     end
 end

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -509,7 +509,7 @@ M.attach = function(bufnr, lang)
             local row, col = unpack(vim.api.nvim_win_get_cursor(0))
             vim.api.nvim_buf_set_text(bufnr, row-1, col, row-1, col, { '>' })
             M.close_tag()
-            vim.cmd.normal'l'
+            vim.api.nvim_win_set_cursor(0, {row, col+1})
           end
         })
         end

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -502,9 +502,16 @@ M.attach = function(bufnr, lang)
     if is_in_table(M.tbl_filetypes, vim.bo.filetype) then
         setup_ts_tag()
         if M.enable_close == true then
-            vim.cmd(
-                [[inoremap <silent> <buffer> > ><c-c>:lua require('nvim-ts-autotag.internal').close_tag()<CR>a]]
-            )
+        vim.api.nvim_buf_set_keymap(bufnr, 'i', ">", ">", {
+          noremap = true,
+          silent = true,
+          callback = function()
+            local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+            vim.api.nvim_buf_set_text(bufnr, row-1, col, row-1, col, { '>' })
+            M.close_tag()
+            vim.cmd.normal'l'
+          end
+        })
         end
         if M.enable_rename == true then
             bufnr = bufnr or vim.api.nvim_get_current_buf()

--- a/sample/index.ts
+++ b/sample/index.ts
@@ -1,0 +1,6 @@
+const html = x => x;
+html`
+
+
+
+`

--- a/tests/closetag_spec.lua
+++ b/tests/closetag_spec.lua
@@ -194,6 +194,16 @@ local data = {
     --     before = [[<div| ]],
     --     after = [[<div>|</div> ]],
     -- },
+    {
+
+        name = '19 lit template div',
+        filepath = './sample/index.ts',
+        filetype = 'typescript',
+        linenr = 3,
+        key = [[>]],
+        before = [[<div| ]],
+        after = [[<div>|</div> ]],
+    },
 }
 
 local autotag = require('nvim-ts-autotag')


### PR DESCRIPTION
closes #32 

```js
const ex = html`<div`
//                  ^ cursor
```
Pressing `>` in insert mode produces:

```js
const ex = html`<div></div>`
//                   ^ cursor
```
then, <kbd>esc</kbd>`bciwp`<kbd>esc</kbd> produces:

```js
const ex = html`<p></p>`
```

also refactors attach function to use lua apis instead of vim.cmd