### PR TITLE
add filetype support for Elixir's HEEx templates and files

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -11,7 +11,8 @@ M.tbl_filetypes = {
     'php',
     'markdown',
     'glimmer','handlebars','hbs',
-    'htmldjango'
+    'htmldjango',
+    'elixir', 'heex'
 }
 
 M.tbl_skipTag = {
@@ -22,7 +23,7 @@ M.tbl_skipTag = {
 local ERROR_TAG = "ERROR"
 
 local HTML_TAG = {
-    filetypes              = {'html', 'php', 'xml', 'markdown', 'htmldjango'},
+    filetypes              = {'html', 'php', 'xml', 'markdown', 'htmldjango', 'elixir', 'heex'},
     start_tag_pattern      = 'start_tag',
     start_name_tag_pattern = 'tag_name',
     end_tag_pattern        = "end_tag",


### PR DESCRIPTION
autotag works great for me, but, it does not work in my Elixir files. However, it works perfectly for me when I include the elixir and heex filetypes here. In Elixir speak, the changes to this file allows me to have html tag closing enabled within "HEEx templates and .heex files". It does not enable html tag closing within ".eex" files which is fine as Elixir has moved to using .heex files instead of the older .eex files. Much Respect!