### PR TITLE
fix: `vim.treesitter.query.get_node_text` deprecated

### DIFF
--- a/lua/nvim-ts-autotag/utils.lua
+++ b/lua/nvim-ts-autotag/utils.lua
@@ -1,10 +1,10 @@
 local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
 local log = require('nvim-ts-autotag._log')
-local get_node_text = vim.treesitter.query.get_node_text or ts_utils.get_node_text
+local get_node_text = vim.treesitter.get_node_text or vim.treesitter.query.get_node_text or ts_utils.get_node_text
 local M = {}
 
 M.get_node_text = function(node)
-    local txt = get_node_text(node, vim.api.nvim_get_current_buf())
+    local _, txt = pcall(get_node_text, node, vim.api.nvim_get_current_buf())
     return vim.split(txt, '\n') or {}
 end
 


### PR DESCRIPTION
`vim.treesitter.query.get_node_text` is deprecated. Use `vim.treesitter.get_node_text` instead.