### PR TITLE
Fix conflict with coq_nvim. Issue 100 fix

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -330,7 +330,6 @@ M.close_tag = function()
     buf_parser:parse()
     local result, tag_name = check_close_tag()
     if result == true and tag_name ~= nil then
-      -- vim.cmd(string.format([[normal! a</%s>]], tag_name))
        vim.api.nvim_put({string.format("</%s>", tag_name)}, "", true, false)
        vim.cmd([[normal! F>]])
    end


### PR DESCRIPTION
[issue](https://github.com/windwp/nvim-ts-autotag/issues/100)

With Coq_nvim there's a weird issue where it just bugs out and throws this crazy error about trying to edit an unmodifiable location, but this should patch it pretty well. 

That being said, I just wanna hop onto the GPT train and say: I do not know lua. I don't even know the basics about making a nvim plugin. This is all greek to me. I didn't even know how this error even happened. I'm a college student, man... I don't know what I'm doing. 

It took me half an hour and 10 prompts with gpt3.5turbo to get this to work. 

What a time to be alive...