### PR TITLE
feat: add mustache filetype

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -8,13 +8,26 @@ local M = {}
 
 -- stylua: ignore
 M.tbl_filetypes = {
-    'html', 'javascript', 'typescript', 'javascriptreact', 'typescriptreact', 'svelte', 'vue', 'tsx', 'jsx', 'rescript',
-    'xml',
-    'php',
-    'markdown',
-    'astro', 'glimmer', 'handlebars', 'hbs',
-    'htmldjango',
+    'astro',
     'eruby'
+    'glimmer',
+    'handlebars',
+    'hbs',
+    'html',
+    'htmldjango',
+    'javascript',
+    'javascriptreact',
+    'jsx',
+    'markdown',
+    'mustache',
+    'php',
+    'rescript',
+    'svelte',
+    'tsx',
+    'typescript',
+    'typescriptreact',
+    'vue',
+    'xml',
 }
 
 -- stylua: ignore


### PR DESCRIPTION
This commit cleans up the formatting for the filetype list and adds support for the [Mustache](http://mustache.github.io/) templating language.