### PR TITLE
Added information to the README about enabling XML support in Treesitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ vim.lsp.handlers['textDocument/publishDiagnostics'] = vim.lsp.with(
     }
 )
 ```
+
+### Enable Treesitter in XML files
+
+nvim-treesitter [doesn't have an XML parser](https://github.com/nvim-treesitter/nvim-treesitter/issues/3295). Instead you can configure treesitter to use the HTML parser, which isn't perfect but works fine.
+```lua
+-- Use the HTML parser for XML files
+vim.treesitter.language.register("html", "xml")
+```
+
 ## Default values
 
 ``` lua


### PR DESCRIPTION
I noticed that this plugin wasn't working on XML files. It turns out that there is no XML parser available in Treesitter, so Treesitter just doesn't start in XML files. There is a parser for HTML available though, which is not perfect but works fine. Work is being done on a proper XML parser as we speak (https://github.com/nvim-treesitter/nvim-treesitter/pull/5194) but it's not quite there yet.

I wrote a bit of info on how to configure this so others don't need to figure this out for themselves.