### PR TITLE
Remove htmldjango from HBS templates

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -67,7 +67,7 @@ local JSX_TAG = {
 
 -- stylua: ignore
 local HBS_TAG = {
-    filetypes              = { 'glimmer', 'handlebars', 'hbs', 'htmldjango' },
+    filetypes              = { 'glimmer', 'handlebars', 'hbs' },
     start_tag_pattern      = 'element_node_start',
     start_name_tag_pattern = 'tag_name',
     end_tag_pattern        = 'element_node_end',


### PR DESCRIPTION
I believe this was mistakenly added in 25698e4. The htmldjango treesitter parser seems to use the same tag names as the HTML parser, so the use of the HBS tag patterns was causing autotag to do nothing in htmldjango filetypes.

Fixes #127 