### PR TITLE
fix: Fix bugs present in the latest version of neovim and treesitter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            url: https://github.com/neovim/neovim/releases/download/v0.7.0/nvim-linux64.tar.gz
+            url: https://github.com/neovim/neovim/releases/download/v0.9.1/nvim-linux64.tar.gz
             manager: sudo apt-get
             packages: -y fd-find
     steps:
@@ -34,7 +34,7 @@ jobs:
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
           git clone --depth 1 https://github.com/nvim-lua/popup.nvim ~/.local/share/nvim/site/pack/vendor/start/popup.nvim
-          git clone --depth 1 --branch v0.7.2 https://github.com/nvim-treesitter/nvim-treesitter ~/.local/share/nvim/site/pack/vendor/start/nvim-treesitter
+          git clone --depth 1 --branch v0.9.1 https://github.com/nvim-treesitter/nvim-treesitter ~/.local/share/nvim/site/pack/vendor/start/nvim-treesitter
           git clone --depth 1 https://github.com/nvim-treesitter/playground ~/.local/share/nvim/site/pack/vendor/start/playground
           git clone --depth 1 https://github.com/nkrkv/nvim-treesitter-rescript  ~/.local/share/nvim/site/pack/vendor/start/nvim-treesitter-rescript
           ln -s $(pwd) ~/.local/share/nvim/site/pack/vendor/start

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -305,6 +305,10 @@ local function find_start_tag(current)
         return nil
     end
 
+    if not current then
+        return nil
+    end
+
     if current:type() == "regex" or current:type() == "element" then
         return nil
     end

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -400,7 +400,17 @@ M.close_slash_tag = function()
     buf_parser:parse()
     local result, tag_name = check_close_tag(true)
     if result == true and tag_name ~= nil then
-        vim.api.nvim_put({ string.format("%s>", tag_name) }, "", true, true)
+        local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+
+        local previous_character = vim.api.nvim_buf_get_text(0, row - 1, col - 1, row - 1, col, {})[1]
+
+        -- just close tag if it's an autoclose tag
+        if previous_character == "<" then
+            vim.api.nvim_put({ string.format("%s>", tag_name) }, "", true, true)
+        else
+            vim.api.nvim_put({ ">" }, "", true, true)
+        end
+
         vim.cmd([[normal! F>]])
     end
 end

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -285,6 +285,12 @@ local function find_tag_node(opt)
     if is_in_table(tbl_name_pattern, node:type()) then
         return node
     end
+
+    -- check current node is jsx fragment
+    if get_tag_name(node) == "</>" then
+        return node
+    end
+
     return name_node
 end
 
@@ -484,6 +490,12 @@ local function rename_start_tag()
             target = tag_node,
             pattern = ERROR_TAG,
         })
+
+        -- In recent version of treesitter jsx fragment don't use error tag
+        if get_tag_name(close_tag_node) == "</>" then
+            error_node = close_tag_node
+        end
+
         if error_node == nil then
             log.debug("do replace")
             local close_tag_name = get_tag_name(close_tag_node)

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -51,11 +51,11 @@ local JSX_TAG = {
         'typescript.tsx', 'javascript', 'typescript', 'rescript'
     },
     start_tag_pattern      = 'jsx_opening_element|start_tag',
-    start_name_tag_pattern = 'identifier|nested_identifier|tag_name|jsx_identifier',
+    start_name_tag_pattern = 'identifier|nested_identifier|tag_name|jsx_identifier|member_expression',
     end_tag_pattern        = 'jsx_closing_element|end_tag',
     end_name_tag_pattern   = 'identifier|tag_name',
     close_tag_pattern      = 'jsx_closing_element|nested_identifier|jsx_identifier|erroneous_end_tag|end_tag',
-    close_name_tag_pattern = 'identifier|nested_identifier|jsx_identifier|erroneous_end_tag_name|tag_name',
+    close_name_tag_pattern = 'identifier|nested_identifier|jsx_identifier|erroneous_end_tag_name|tag_name|member_expression',
     element_tag            = 'jsx_element|element',
     skip_tag_pattern       = {
         'jsx_closing_element', 'jsx_expression', 'string', 'jsx_attribute', 'end_tag',
@@ -299,7 +299,7 @@ local function find_start_tag(current)
         return nil
     end
 
-    if current:type() ~= "ERROR" then
+    if current:type() == "regex" or current:type() == "element" then
         return nil
     end
 

--- a/tests/close_slash_tag_spec.lua
+++ b/tests/close_slash_tag_spec.lua
@@ -201,6 +201,15 @@ local data = {
         before = [[<Img src="abc"| ]],
         after = [[<Img src="abc"/>| ]],
     },
+    {
+        name = '21 typescriptreact regex should do nothing after inputting final /',
+        filepath = './sample/index.tsx',
+        filetype = 'typescriptreact',
+        linenr = 7,
+        key = [[/]],
+        before = [[const regex = /hoi| ]],
+        after = [[const regex = /hoi/| ]],
+    },
 }
 
 local autotag = require('nvim-ts-autotag')

--- a/tests/close_slash_tag_spec.lua
+++ b/tests/close_slash_tag_spec.lua
@@ -183,6 +183,24 @@ local data = {
         before = [[<%= <div| %>]],
         after = [[<%= <div/| %> ]],
     },
+    {
+        name = '19 typescriptreact self closing tag close after inputting /',
+        filepath = './sample/index.tsx',
+        filetype = 'typescriptreact',
+        linenr = 12,
+        key = [[/]],
+        before = [[<div| ]],
+        after = [[<div/>| ]],
+    },
+    {
+        name = '20 typescriptreact self closing tag with attribute close after inputting /',
+        filepath = './sample/index.tsx',
+        filetype = 'typescriptreact',
+        linenr = 12,
+        key = [[/]],
+        before = [[<Img src="abc"| ]],
+        after = [[<Img src="abc"/>| ]],
+    },
 }
 
 local autotag = require('nvim-ts-autotag')


### PR DESCRIPTION
# Introduction

Hoi!
It's me again, the person who introduced the PR #116 that normally solves #94 (Anyway, it works well for me).
Except it only works partially, let me explain.

Operations like closing tags for `<div>Hoi</` properly transform to `<div>Hoi</div>` but I found recently when I was using TSX that self closing tags like `<Img />` ***can't be written with my option***.

There is actually a bug that when you type `/`, the code will think you are trying to close the tag *(which is not the case of course)* so it will write `<Img/Img>` which is awful.

So I initially decided to correct this but I discovered that the plugin was broken....

Yes, broken with the latest version of Treesitter.

So this PR will also address making the code work with the latest Treesitter version.

# The changes

I can't exactly remember what all the issues were but here are some major ones I fixed with this PR:

## Nested Identifiers don't close after inputting `/`
```tsx
<Opt.Input></
```

## Rename of Nested Identifiers or JSX fragments don't work or do some strange behavior
```tsx
<div>
    <>
    </>
</div>
```
Gives when trying to rename the fragment:
```tsx
<div>
    <p>
    </>
</p>
```

## Sometimes closing after inputting `/` just doesn't work
```tsx
<div></
```

## You can't close self tags
```tsx
<AppImage src="/hoi.png"
```
With the `/` that transforms to the awful original bug
```tsx
<AppImage src="/hoi.png"/AppImage>
```

# Conclusion

So after taking 6 hours to fix all of those problems, I am happy to present you with this PR that fixes every one of them.

I also updated the CI to the latest Neovim and Treesitter versions because some of the issues that were fixed were only caught by the CI with the latest version of Treesitter since Treesitter evolves and some tag identifiers change.

For example, the JSX fragment doesn't throw "Error" tags anymore so I need to directly check if the node is a Fragment in the buffer (which is an easy task).

If there is anything you see that could be improved, let me know ^^.

***In any case, I love my days in the world of Neovim and I am even more honored to now be part of this community by helping this plugin once again.***

PS: Sorry if this PR fixes more of my bugs that I introduced in #116 than anything else but that's life :eyes: