### PR TITLE
fix: allow `enable_close` to be set to false

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -108,7 +108,7 @@ M.setup = function(opts)
     if opts.enable_rename ~= nil then
         M.enable_rename = opts.enable_rename
     end
-    if opts.enable_close then
+    if opts.enable_close ~= nil then
         M.enable_close = opts.enable_close
     end
     if opts.enable_close_on_slash ~= nil then


### PR DESCRIPTION
This PR fixes setting the option `enable_close` to false as stated in #147 

PS: as I mentioned in the issue I couldn't find a proper solution for the problem, but I'll be happy to help and even put a possible fix for that in this PR if any suggestions raise.