### PR TITLE
Templ tag completion

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -8,7 +8,7 @@ local M = {}
 
 -- stylua: ignore
 M.tbl_filetypes = {
-    'html', 'javascript', 'typescript', 'javascriptreact', 'typescriptreact', 'svelte', 'vue', 'tsx', 'jsx', 'rescript',
+    'html', 'javascript', 'typescript', 'javascriptreact', 'typescriptreact', 'svelte', 'vue', 'tsx', 'jsx', 'rescript','templ',
     'xml',
     'php',
     'markdown',
@@ -32,6 +32,7 @@ local HTML_TAG = {
         'markdown',
         'php',
         'xml',
+        'templ',
     },
     start_tag_pattern      = { 'start_tag' },
     start_name_tag_pattern = { 'tag_name' },
@@ -244,7 +245,6 @@ local function find_tag_node(opt)
             pattern = tag_pattern,
             skip_tag_pattern = skip_tag_pattern,
         })
-
     else
         node = find_parent_match({
             target = target,
@@ -262,7 +262,6 @@ local function find_tag_node(opt)
     if name_node then
         return name_node
     end
-
 
     -- check current node is have same name of tag_match
     if is_in_table(name_tag_pattern, node:type()) then
@@ -446,7 +445,6 @@ local function rename_start_tag()
         name_tag_pattern = ts_tag.close_name_tag_pattern,
     })
 
-
     if close_tag_node == nil then
         close_tag_node = find_child_tag_node({
             target = tag_node:parent(),
@@ -471,8 +469,8 @@ local function rename_start_tag()
             -- log.debug("do replace")
             -- log.debug(tag_name)
             -- log.debug(close_tag_name)
-            if close_tag_name == '>' then
-                tag_name = tag_name .. '>'
+            if close_tag_name == ">" then
+                tag_name = tag_name .. ">"
             end
             replace_text_node(close_tag_node, tag_name)
         end
@@ -517,7 +515,7 @@ local function rename_end_tag()
     if start_tag_node ~= nil then
         local start_tag_name = get_tag_name(start_tag_node)
         if tag_name ~= start_tag_name then
-            log.debug('replace end tag')
+            log.debug("replace end tag")
             replace_text_node(start_tag_node, tag_name)
         end
     end
@@ -536,8 +534,8 @@ local function is_before(regex, range)
     end
 end
 
-local is_before_word = is_before('%w', 1)
-local is_before_arrow = is_before('<', 0)
+local is_before_word = is_before("%w", 1)
+local is_before_arrow = is_before("<", 0)
 
 M.rename_tag = function()
     if is_before_word() and parsers.has_parser() then
@@ -554,7 +552,7 @@ M.attach = function(bufnr, lang)
 
     if is_in_table(M.tbl_filetypes, vim.bo.filetype) then
         setup_ts_tag()
-        local group = vim.api.nvim_create_augroup('nvim-ts-autotag', { clear = true })
+        local group = vim.api.nvim_create_augroup("nvim-ts-autotag", { clear = true })
         if M.enable_close == true then
             vim.api.nvim_buf_set_keymap(bufnr or 0, "i", ">", ">", {
                 noremap = true,
@@ -575,7 +573,7 @@ M.attach = function(bufnr, lang)
                     local row, col = unpack(vim.api.nvim_win_get_cursor(0))
                     vim.api.nvim_buf_set_text(bufnr or 0, row - 1, col, row - 1, col, { "/" })
                     if is_before_arrow() then
-                        log.debug('is_before_arrow')
+                        log.debug("is_before_arrow")
                         M.close_slash_tag()
                     end
                     local new_row, new_col = unpack(vim.api.nvim_win_get_cursor(0))

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -32,7 +32,6 @@ local HTML_TAG = {
         'markdown',
         'php',
         'xml',
-        'templ',
     },
     start_tag_pattern      = { 'start_tag' },
     start_name_tag_pattern = { 'tag_name' },
@@ -47,7 +46,7 @@ local HTML_TAG = {
 local JSX_TAG = {
     filetypes              = {
         'typescriptreact', 'javascriptreact', 'javascript.jsx',
-        'typescript.tsx', 'javascript', 'typescript', 'rescript'
+        'typescript.tsx', 'javascript', 'typescript', 'rescript', 'templ',
     },
     start_tag_pattern      = { 'jsx_opening_element', 'start_tag' },
     start_name_tag_pattern = { 'identifier', 'nested_identifier', 'tag_name', 'member_expression', 'jsx_identifier' },

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -8,10 +8,10 @@ local M = {}
 
 -- stylua: ignore
 M.tbl_filetypes = {
-    'html', 'javascript', 'typescript', 'javascriptreact', 'typescriptreact', 'svelte', 'vue', 'tsx', 'jsx', 'rescript','templ',
+    'html', 'javascript', 'typescript', 'javascriptreact', 'typescriptreact', 'svelte', 'vue', 'tsx', 'jsx', 'rescript',
     'xml',
     'php',
-    'markdown',
+    'markdown','templ',
     'astro', 'glimmer', 'handlebars', 'hbs',
     'htmldjango',
     'eruby'
@@ -32,6 +32,7 @@ local HTML_TAG = {
         'markdown',
         'php',
         'xml',
+        'templ',
     },
     start_tag_pattern      = { 'start_tag' },
     start_name_tag_pattern = { 'tag_name' },
@@ -46,7 +47,7 @@ local HTML_TAG = {
 local JSX_TAG = {
     filetypes              = {
         'typescriptreact', 'javascriptreact', 'javascript.jsx',
-        'typescript.tsx', 'javascript', 'typescript', 'rescript', 'templ',
+        'typescript.tsx', 'javascript', 'typescript', 'rescript',
     },
     start_tag_pattern      = { 'jsx_opening_element', 'start_tag' },
     start_name_tag_pattern = { 'identifier', 'nested_identifier', 'tag_name', 'member_expression', 'jsx_identifier' },

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -47,7 +47,7 @@ local HTML_TAG = {
 local JSX_TAG = {
     filetypes              = {
         'typescriptreact', 'javascriptreact', 'javascript.jsx',
-        'typescript.tsx', 'javascript', 'typescript', 'rescript',
+        'typescript.tsx', 'javascript', 'typescript', 'rescript'
     },
     start_tag_pattern      = { 'jsx_opening_element', 'start_tag' },
     start_name_tag_pattern = { 'identifier', 'nested_identifier', 'tag_name', 'member_expression', 'jsx_identifier' },
@@ -484,8 +484,8 @@ local function rename_start_tag()
             -- log.debug("do replace")
             -- log.debug(tag_name)
             -- log.debug(close_tag_name)
-            if close_tag_name == ">" then
-                tag_name = tag_name .. ">"
+            if close_tag_name == '>' then
+                tag_name = tag_name .. '>'
             end
             replace_text_node(close_tag_node, tag_name)
         end
@@ -530,7 +530,7 @@ local function rename_end_tag()
     if start_tag_node ~= nil then
         local start_tag_name = get_tag_name(start_tag_node)
         if tag_name ~= start_tag_name then
-            log.debug("replace end tag")
+            log.debug('replace end tag')
             replace_text_node(start_tag_node, tag_name)
         end
     end
@@ -549,8 +549,8 @@ local function is_before(regex, range)
     end
 end
 
-local is_before_word = is_before("%w", 1)
-local is_before_arrow = is_before("<", 0)
+local is_before_word = is_before('%w', 1)
+local is_before_arrow = is_before('<', 0)
 
 M.rename_tag = function()
     if is_before_word() and parsers.has_parser() then
@@ -567,7 +567,7 @@ M.attach = function(bufnr, lang)
 
     if is_in_table(M.tbl_filetypes, vim.bo.filetype) then
         setup_ts_tag()
-        local group = vim.api.nvim_create_augroup("nvim-ts-autotag", { clear = true })
+        local group = vim.api.nvim_create_augroup('nvim-ts-autotag', { clear = true })
         if M.enable_close == true then
             vim.api.nvim_buf_set_keymap(bufnr or 0, "i", ">", ">", {
                 noremap = true,
@@ -588,7 +588,7 @@ M.attach = function(bufnr, lang)
                     local row, col = unpack(vim.api.nvim_win_get_cursor(0))
                     vim.api.nvim_buf_set_text(bufnr or 0, row - 1, col, row - 1, col, { "/" })
                     if is_before_arrow() then
-                        log.debug("is_before_arrow")
+                        log.debug('is_before_arrow')
                         M.close_slash_tag()
                     end
                     local new_row, new_col = unpack(vim.api.nvim_win_get_cursor(0))

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -11,10 +11,11 @@ M.tbl_filetypes = {
     'html', 'javascript', 'typescript', 'javascriptreact', 'typescriptreact', 'svelte', 'vue', 'tsx', 'jsx', 'rescript',
     'xml',
     'php',
-    'markdown','templ',
+    'markdown',
     'astro', 'glimmer', 'handlebars', 'hbs',
     'htmldjango',
-    'eruby'
+    'eruby',
+    'templ',
 }
 
 -- stylua: ignore
@@ -32,7 +33,6 @@ local HTML_TAG = {
         'markdown',
         'php',
         'xml',
-        'templ',
     },
     start_tag_pattern      = { 'start_tag' },
     start_name_tag_pattern = { 'tag_name' },
@@ -91,10 +91,25 @@ local SVELTE_TAG = {
     skip_tag_pattern       = { 'quoted_attribute_value', 'end_tag' },
 }
 
+local TEMPL_TAG = {
+    filetypes = {
+        "templ",
+    },
+    start_tag_pattern = { "tag_start" },
+    start_name_tag_pattern = { "element_identifier" },
+    end_tag_pattern = { "tag_end" },
+    end_name_tag_pattern = { "element_identifier" },
+    close_tag_pattern = { "erroneous_end_tag" },
+    close_name_tag_pattern = { "erroneous_end_tag_name" },
+    element_tag = { "element" },
+    skip_tag_pattern = { "quoted_attribute_value", "tag_end" },
+}
+
 local all_tag = {
     HBS_TAG,
     SVELTE_TAG,
     JSX_TAG,
+    TEMPL_TAG,
 }
 M.enable_rename = true
 M.enable_close = true


### PR DESCRIPTION
resolves #152 

out of the main configuration

```lua
    start_tag_pattern = { "tag_start" },
    start_name_tag_pattern = { "element_identifier" },
    end_tag_pattern = { "tag_end" },
    end_name_tag_pattern = { "element_identifier" },
    close_tag_pattern = { "erroneous_end_tag" },
    close_name_tag_pattern = { "erroneous_end_tag_name" },
    element_tag = { "element" },
    skip_tag_pattern = { "quoted_attribute_value", "tag_end" },
```

i only encountered and correctly modified for my new type
```lua
start_tag_pattern
start_name_tag_pattern
end_tag_pattern
end_name_tag_pattern
```

The other variables i assumed from other elements, but i correctly now have in a simple templ file auto tag closing


https://github.com/windwp/nvim-ts-autotag/assets/2253299/c7d1b6d3-56a6-4da2-b1b7-8ee79164efd3

