### PR TITLE
feat: remove dependency on `nvim-treesitter`. Needed for `nvim-treesitter` rewrite. Requires Neovim >= 0.9.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            url: https://github.com/neovim/neovim/releases/download/v0.7.0/nvim-linux64.tar.gz
+            url: https://github.com/neovim/neovim/releases/download/v0.9.5/nvim-linux64.tar.gz
             manager: sudo apt-get
             packages: -y fd-find
     steps:
@@ -43,5 +43,6 @@ jobs:
         run: |
           export PATH="${PWD}/_neovim/bin:${PATH}"
           export VIM="${PWD}/_neovim/share/nvim/runtime"
-          nvim --headless -u tests/minimal.vim -c "TSInstallSync html javascript typescript svelte vue tsx php glimmer rescript" -c "q"
+          # nvim --headless -u tests/minimal.vim -c "q"
+          nvim --headless -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim', sequential = true}"
           make test

--- a/lua/nvim-ts-autotag.lua
+++ b/lua/nvim-ts-autotag.lua
@@ -3,14 +3,17 @@ local internal = require("nvim-ts-autotag.internal")
 local M = {}
 
 function M.init()
-  require "nvim-treesitter".define_modules {
-    autotag = {
-      module_path = 'nvim-ts-autotag.internal',
-      is_supported = function(lang)
-        return internal.is_supported(lang)
-      end
-    }
-  }
+  local ts = require('nvim-treesitter')
+  if ts and ts.define_modules then
+    require('nvim-treesitter').define_modules({
+      autotag = {
+        module_path = 'nvim-ts-autotag.internal',
+        is_supported = function(lang)
+          return internal.is_supported(lang)
+        end,
+      },
+    })
+  end
 end
 
 function M.setup(opts)

--- a/lua/nvim-ts-autotag/utils.lua
+++ b/lua/nvim-ts-autotag/utils.lua
@@ -1,6 +1,5 @@
-local _, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
 local log = require('nvim-ts-autotag._log')
-local get_node_text = vim.treesitter.get_node_text or vim.treesitter.query.get_node_text or ts_utils.get_node_text
+local get_node_text = vim.treesitter.get_node_text or vim.treesitter.query.get_node_text
 local M = {}
 
 M.get_node_text = function(node)

--- a/tests/minimal.vim
+++ b/tests/minimal.vim
@@ -29,6 +29,13 @@ _G.__is_log=true
 _G.ts_filetypes = {
   'html', 'javascript', 'typescript', 'svelte', 'vue', 'tsx', 'php', 'glimmer', 'rescript', 'embedded_template'
 }
+require("nvim-treesitter.configs").setup({
+    ensure_installed = _G.ts_filetypes,
+    highlight = { enable = true },
+    sync_install = true
+})
+vim.treesitter.language.register('tsx', 'typescriptreact')
+vim.treesitter.language.register('embedded_template', 'eruby')
 require("plenary/busted")
 vim.cmd[[luafile ./tests/test-utils.lua]]
 require("nvim-ts-autotag").setup({


### PR DESCRIPTION
This PR removes the dependency on `nvim-treesitter` and uses Neovim's treesitter methods.

Without this PR, `nvim-ts-autotag` will be broken once the `nvim-treesitter` rewrite is released.

Some tests related to `eruby` seems to fail, but I'm not sure this is due to these code changes.