### PR TITLE
fix: wrap vim.treesitter.get_parser in pcall

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -243,8 +243,8 @@ local function check_close_tag(close_slash_tag)
 end
 
 M.close_tag = function()
-    local buf_parser = vim.treesitter.get_parser()
-    if not buf_parser then
+    local ok, buf_parser = pcall(vim.treesitter.get_parser)
+    if not ok then
         return
     end
     buf_parser:parse(true)
@@ -256,8 +256,8 @@ M.close_tag = function()
 end
 
 M.close_slash_tag = function()
-    local buf_parser = vim.treesitter.get_parser()
-    if not buf_parser then
+    local ok, buf_parser = pcall(vim.treesitter.get_parser)
+    if not ok then
         return
     end
     buf_parser:parse(true)

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -430,8 +430,8 @@ local is_before_arrow = is_before("<", 0)
 
 M.rename_tag = function()
     if is_before_word() then
-        local parser = vim.treesitter.get_parser()
-        if not parser then
+        local ok, parser = pcall(vim.treesitter.get_parser)
+        if not ok then
             return
         end
         parser:parse(true)

--- a/lua/nvim-ts-autotag/utils.lua
+++ b/lua/nvim-ts-autotag/utils.lua
@@ -65,8 +65,8 @@ M.get_node_at_cursor = function(winnr)
     local row, col = unpack(vim.api.nvim_win_get_cursor(winnr))
     row = row - 1
     local buf = vim.api.nvim_win_get_buf(winnr)
-    local root_lang_tree = vim.treesitter.get_parser(buf)
-    if not root_lang_tree then
+    local ok, root_lang_tree = pcall(vim.treesitter.get_parser, buf)
+    if not ok then
         return
     end
 


### PR DESCRIPTION
Fixes https://github.com/windwp/nvim-ts-autotag/issues/183

Tested manually on a local ruby erb file. Please let me know if you would like other tests added for this.