### PR TITLE
fix: update luadoc to allow for empty setup call

### DIFF
--- a/lua/nvim-ts-autotag/config/plugin.lua
+++ b/lua/nvim-ts-autotag/config/plugin.lua
@@ -141,7 +141,7 @@ local Setup = {
 }
 
 --- Do general plugin setup
----@param opts nvim-ts-autotag.PluginSetup|nil
+---@param opts nvim-ts-autotag.PluginSetup?
 function Setup.setup(opts)
     opts = opts or {}
     if Setup.did_setup then

--- a/lua/nvim-ts-autotag/config/plugin.lua
+++ b/lua/nvim-ts-autotag/config/plugin.lua
@@ -141,7 +141,7 @@ local Setup = {
 }
 
 --- Do general plugin setup
----@param opts nvim-ts-autotag.PluginSetup
+---@param opts nvim-ts-autotag.PluginSetup|nil
 function Setup.setup(opts)
     opts = opts or {}
     if Setup.did_setup then


### PR DESCRIPTION
Previously I get the following warning when using the default config (by passing nothing):

`This function requires 1 argument(s) but instead it is receiving 0. Lua Diagnostics. (missing-parameter) [83, 8]`

![image](https://github.com/windwp/nvim-ts-autotag/assets/7804791/424ecd12-32ed-4304-a5e8-1a4010c79f76)

The code itself works fine, it will use the default config.

This PR just updates the expected argument for `setup` to allow for `nil` as well