### PR TITLE
Add rust file supports 

### DIFF
--- a/lua/nvim-ts-autotag/config/plugin.lua
+++ b/lua/nvim-ts-autotag/config/plugin.lua
@@ -147,7 +147,7 @@ local Setup = {
         ["rescript"] = "typescriptreact",
         ["handlebars"] = "glimmer",
         ["hbs"] = "glimmer",
-        ["rust"] = "html",
+        ["rust"] = "rust",
     },
     per_filetype = {},
 }

--- a/lua/nvim-ts-autotag/config/plugin.lua
+++ b/lua/nvim-ts-autotag/config/plugin.lua
@@ -100,7 +100,7 @@ local function setup_tag_configs()
         skip_tag_pattern = { "quoted_attribute_value", "tag_end", "attribute", "value" },
     }))
 
-    TagConfigs:add(base_cfg:extend("rust",{
+    TagConfigs:add(html_tag_cfg:extend("rust",{
         start_tag_pattern = { 'open_tag' },
         start_name_tag_pattern = { 'node_identifier' },
         end_tag_pattern = { 'close_tag' },

--- a/lua/nvim-ts-autotag/config/plugin.lua
+++ b/lua/nvim-ts-autotag/config/plugin.lua
@@ -100,15 +100,15 @@ local function setup_tag_configs()
         skip_tag_pattern = { "quoted_attribute_value", "tag_end", "attribute", "value" },
     }))
 
-    TagConfigs:add(base_cfg:extend("rust",{
-    start_tag_pattern = { 'open_tag' },
-    start_name_tag_pattern = { 'node_identifier' },
-    end_tag_pattern = { 'close_tag' },
-    end_name_tag_pattern = { 'node_identifier' },
-    close_tag_pattern = { 'close_tag' },
-    close_name_tag_pattern = { 'close_tag', 'node_identifier' },
-    element_tag = { 'element_node' },
-    skip_tag_pattern = { 'close_tag', 'node_attribute', 'block' },
+    TagConfigs:add(base_cfg:extend("rust", {
+        start_tag_pattern = { "open_tag" },
+        start_name_tag_pattern = { "node_identifier" },
+        end_tag_pattern = { "close_tag" },
+        end_name_tag_pattern = { "node_identifier" },
+        close_tag_pattern = { "close_tag" },
+        close_name_tag_pattern = { "close_tag", "node_identifier" },
+        element_tag = { "element_node" },
+        skip_tag_pattern = { "close_tag", "node_attribute", "block" },
     }))
 end
 

--- a/lua/nvim-ts-autotag/config/plugin.lua
+++ b/lua/nvim-ts-autotag/config/plugin.lua
@@ -100,15 +100,15 @@ local function setup_tag_configs()
         skip_tag_pattern = { "quoted_attribute_value", "tag_end", "attribute", "value" },
     }))
 
-    TagConfigs:add(html_tag_cfg:extend("rust",{
-        start_tag_pattern = { 'open_tag' },
-        start_name_tag_pattern = { 'node_identifier' },
-        end_tag_pattern = { 'close_tag' },
-        end_name_tag_pattern = { 'node_identifier' },
-        close_tag_pattern = { 'close_tag' },
-        close_name_tag_pattern = { 'close_tag', 'node_identifier' },
-        element_tag = { 'element_node' },
-        skip_tag_pattern = { 'close_tag', 'node_attribute', 'block' },
+    TagConfigs:add(base_cfg:extend("rust",{
+    start_tag_pattern = { 'open_tag' },
+    start_name_tag_pattern = { 'node_identifier' },
+    end_tag_pattern = { 'close_tag' },
+    end_name_tag_pattern = { 'node_identifier' },
+    close_tag_pattern = { 'close_tag' },
+    close_name_tag_pattern = { 'close_tag', 'node_identifier' },
+    element_tag = { 'element_node' },
+    skip_tag_pattern = { 'close_tag', 'node_attribute', 'block' },
     }))
 end
 

--- a/lua/nvim-ts-autotag/config/plugin.lua
+++ b/lua/nvim-ts-autotag/config/plugin.lua
@@ -101,15 +101,14 @@ local function setup_tag_configs()
     }))
 
     TagConfigs:add(base_cfg:extend("rust",{
-    filetypes = { 'rust' },
-    start_tag_pattern = { 'open_tag' },
-    start_name_tag_pattern = { 'node_identifier' },
-    end_tag_pattern = { 'close_tag' },
-    end_name_tag_pattern = { 'node_identifier' },
-    close_tag_pattern = { 'close_tag' },
-    close_name_tag_pattern = { 'close_tag', 'node_identifier' },
-    element_tag = { 'element_node' },
-    skip_tag_pattern = { 'close_tag', 'node_attribute', 'block' },
+        start_tag_pattern = { 'open_tag' },
+        start_name_tag_pattern = { 'node_identifier' },
+        end_tag_pattern = { 'close_tag' },
+        end_name_tag_pattern = { 'node_identifier' },
+        close_tag_pattern = { 'close_tag' },
+        close_name_tag_pattern = { 'close_tag', 'node_identifier' },
+        element_tag = { 'element_node' },
+        skip_tag_pattern = { 'close_tag', 'node_attribute', 'block' },
     }))
 end
 

--- a/lua/nvim-ts-autotag/config/plugin.lua
+++ b/lua/nvim-ts-autotag/config/plugin.lua
@@ -136,6 +136,7 @@ local Setup = {
         ["rescript"] = "typescriptreact",
         ["handlebars"] = "glimmer",
         ["hbs"] = "glimmer",
+        ["rust"] = "html",
     },
     per_filetype = {},
 }

--- a/lua/nvim-ts-autotag/config/plugin.lua
+++ b/lua/nvim-ts-autotag/config/plugin.lua
@@ -99,6 +99,18 @@ local function setup_tag_configs()
         element_tag = { "element" },
         skip_tag_pattern = { "quoted_attribute_value", "tag_end", "attribute", "value" },
     }))
+
+    TagConfigs:add(base_cfg:extend("rust",{
+    filetypes = { 'rust' },
+    start_tag_pattern = { 'open_tag' },
+    start_name_tag_pattern = { 'node_identifier' },
+    end_tag_pattern = { 'close_tag' },
+    end_name_tag_pattern = { 'node_identifier' },
+    close_tag_pattern = { 'close_tag' },
+    close_name_tag_pattern = { 'close_tag', 'node_identifier' },
+    element_tag = { 'element_node' },
+    skip_tag_pattern = { 'close_tag', 'node_attribute', 'block' },
+    }))
 end
 
 ---@class nvim-ts-autotag.Opts


### PR DESCRIPTION
Some frameworks like yew and leptos allow for html inside rust files, just updating implementation of [rayliwell](https://github.com/rayliwell) to add it to the og and keep just one plugin