### PR TITLE
fix: error message when using nvim-treesitter 'main' branch

### DIFF
--- a/lua/nvim-ts-autotag.lua
+++ b/lua/nvim-ts-autotag.lua
@@ -9,6 +9,9 @@ function M.init()
     if not nvim_ts then
         return
     end
+    if nvim_ts.define_modules == nil then
+        return
+    end
     nvim_ts.define_modules({
         autotag = {
             attach = function(bufnr, _)


### PR DESCRIPTION
I am currently using the `main` branch for nvim-treesitter which is the development branch for v1.0

https://github.com/nvim-treesitter/nvim-treesitter/issues/4767#issue-1698676665
> create a new `main` branch (targeting Neovim nightly only) for the new slimmed down installation functionality

This is causing nvim-ts-autotag to output an error, it tries to setup using the deprecated `configs` module, the main branch on TS has this removed. This error shows every time in the command line when opening Neovim.

The change on this PR fixes that error by inferring that we are using the main branch of TS. I tested this change on the latest version v0.9.2 of TS too, so it wont break current configs of users not using the main branch.

## Error (without full stack trace)

```
Failed to source `.../plugin/nvim-ts-autotag.lua`
.../plugin/nvim-ts-autotag.lua: Vim(source):E5113: Error while calling lua chunk:
.../lua/nvim-ts-autotag.lua:12: attempt to call field 'define_modules' (a nil value)
```

## Lazy.nvim config to reproduce

```lua
return {
  {
    "nvim-treesitter/nvim-treesitter",
    lazy = false,
    branch = "main",
    build = ":TSUpdate",
    config = function()
      require("nvim-treesitter").setup({
        ensure_install = { "core", "stable" },
      })
    end,
  },

  {
    "windwp/nvim-ts-autotag",
    dependencies = { "nvim-treesitter/nvim-treesitter" },
    config = function()
      require("nvim-ts-autotag").setup()
    end,
  },
}
```