### PR TITLE
test(refactor): remove invalid test plugins

### DIFF
--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -138,7 +138,5 @@ end
 
 M.setup({
     ["plenary.nvim"] = "https://github.com/nvim-lua/plenary.nvim",
-    ["popup.nvim"] = "https://github.com/nvim-lua/popup.nvim",
     ["nvim-treesitter"] = "https://github.com/nvim-treesitter/nvim-treesitter",
-    ["playground"] = "https://github.com/nvim-treesitter/playground",
 })


### PR DESCRIPTION
Copied from the body of the commit:

> - `popup.nvim` is not referenced anywhere within the plugin and as such
>   should be removed.
> - `playground` is not needed either, it's not referenced and secondly
>   the most important feature from it (:TSPlayground) is covered by
>   Neovim's :InspectTree command in more recent versions of Neovim.
>
> Closes #203 (https://github.com/windwp/nvim-ts-autotag/issues/203)