### PR TITLE
fix: Don't auto tag fragment if not in jsx

### DIFF
--- a/lua/nvim-ts-autotag/utils.lua
+++ b/lua/nvim-ts-autotag/utils.lua
@@ -37,6 +37,13 @@ end
 
 ---@return boolean
 function M.is_react_fragment()
+    local node = vim.treesitter.get_node()
+
+    -- Bail out if the treesitter doesn't recognize `<>` as jsx_opening_element
+    if not node or node:type() ~= "jsx_opening_element" then
+        return false
+    end
+
     local line = vim.fn.getline(".")
     local col = vim.fn.col(".") - 2
     local strpart = vim.fn.strpart(line, col)

--- a/tests/specs/closetag_spec.lua
+++ b/tests/specs/closetag_spec.lua
@@ -255,6 +255,15 @@ local data = {
         before = [[<input| ]],
         after = [[<input>| ]],
     },
+    {
+        name = "28 typescriptreact not close fragment in generic argument delimeters",
+        filepath = "./sample/index.tsx",
+        filetype = "typescriptreact",
+        linenr = 1,
+        key = [[>]],
+        before = [[type Foo = Bar<| ]],
+        after = [[type Foo = Bar<>]],
+    },
 }
 
 local autotag = require("nvim-ts-autotag")


### PR DESCRIPTION
Use treesitter to determine whether node is a jsx_opening_element and use this info to bail out if the user may be writing a generic parameter.

Solves issue mentioned in https://github.com/windwp/nvim-ts-autotag/pull/202#issuecomment-2254467345 where `useState<>` becomes `useState<></>` when the user is typing out a generic type argument in `typescriptreact` files.

A thing to note is that there is still an ambiguity in the grammar while typing:
```tsx
// If the user types:
const foo = <T>
```
```tsx
// It could be a generic function:
const foo = <T>() => { ... };
```
```tsx
// Alternatively it could be a JSX element:
const foo = <T></T>;
```
But generic inline functions are less common than generic types and argument so this PR fixes most cases.