### PR TITLE
fix: call `setup` instead of `init`

### DIFF
--- a/plugin/nvim-ts-autotag.lua
+++ b/plugin/nvim-ts-autotag.lua
@@ -1,1 +1,1 @@
-require("nvim-ts-autotag").init()
+require("nvim-ts-autotag").setup()


### PR DESCRIPTION
Though `init` will be deprecated, it is called automatically when this plugin is loaded, causing loading `nvim-treesitter`, which is no longer needed now.