### PR TITLE
Add HEEx support including Components

### DIFF
--- a/lua/nvim-ts-autotag/config/plugin.lua
+++ b/lua/nvim-ts-autotag/config/plugin.lua
@@ -43,6 +43,16 @@ local function setup_tag_configs()
         end_tag_pattern = { "ETag" },
     }))
 
+    -- Support Elixir HEEX files.
+    -- HEEX is simply HTML with the addition of the <.component></.component> syntax.
+    TagConfigs:add(html_tag_cfg:extend("heex", {
+        start_tag_pattern = { "start_component" },
+        start_name_tag_pattern = { "component_name" },
+        end_tag_pattern = { "end_component" },
+        end_name_tag_pattern = { "component_name" },
+        skip_tag_pattern = { "end_component" },
+    }))
+
     TagConfigs:add(base_cfg:extend("typescriptreact", {
         start_tag_pattern = { "jsx_opening_element", "start_tag" },
         start_name_tag_pattern = {
@@ -135,10 +145,10 @@ local Setup = {
         ["htmlangular"] = "html",
         ["htmldjango"] = "html",
         ["markdown"] = "html",
-        ["elixir"] = "html",
         ["php"] = "html",
         ["twig"] = "html",
         ["blade"] = "html",
+        ["elixir"] = "heex",
         ["javascriptreact"] = "typescriptreact",
         ["javascript.jsx"] = "typescriptreact",
         ["typescript.tsx"] = "typescriptreact",


### PR DESCRIPTION
Add support for HEEx files, including the `<.component></.component>` syntax.

HEEx is nearly the same as HTML except uses the `[start|end]_component` and `component_name` rather than `...tag...`.

Elixir templates are almost always HEEx, so I have also changed the Elixir alias from `html` -> `heex`.

I am already actively using this in my config :)