### PR TITLE
fix neovim freeze when closing a type_identifier

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -46,6 +46,7 @@ local function is_in_template_tag()
     local current_node = cursor_node
     local visited_nodes = {}
     while not (has_element and has_template_string) and current_node do
+        local node_id = current_node:id()
         if visited_nodes[node_id] then
             break
         end

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -44,7 +44,12 @@ local function is_in_template_tag()
     local has_template_string = false
 
     local current_node = cursor_node
+    local visited_nodes = {}
     while not (has_element and has_template_string) and current_node do
+        if visited_nodes[node_id] then
+            break
+        end
+        visited_nodes[node_id] = true
         if not has_element and current_node:type() == "element" then
             has_element = true
         end


### PR DESCRIPTION
close #222 

Avoid a potential infinite loop when checking if `is_in_template_tag()` when closing a `type_indentifier` ts node.