### PR TITLE
fix: handle nil parser in rename_tag for Neovim 0.12+

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -251,7 +251,7 @@ end
 
 M.close_tag = function()
     local ok, buf_parser = pcall(vim.treesitter.get_parser)
-    if not ok then
+    if not ok or not buf_parser then
         return
     end
     buf_parser:parse(true)
@@ -267,7 +267,7 @@ end
 
 M.close_slash_tag = function()
     local ok, buf_parser = pcall(vim.treesitter.get_parser)
-    if not ok then
+    if not ok or not buf_parser then
         return
     end
     buf_parser:parse(true)

--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -441,7 +441,7 @@ local is_before_arrow = is_before("<", 0)
 M.rename_tag = function()
     if is_before_word() then
         local ok, parser = pcall(vim.treesitter.get_parser)
-        if not ok then
+        if not ok or not parser then
             return
         end
         parser:parse(true)

--- a/lua/nvim-ts-autotag/utils.lua
+++ b/lua/nvim-ts-autotag/utils.lua
@@ -14,7 +14,7 @@ function M.is_react_file()
     -- If we are in a `javascript` file, then check the content to see if the
     -- current file counts as a react file
     local ok, buf_parser = pcall(vim.treesitter.get_parser)
-    if not ok then
+    if not ok or not buf_parser then
         return false
     end
 
@@ -150,7 +150,7 @@ M.get_node_at_cursor = function(winnr)
     row = row - 1
     local buf = vim.api.nvim_win_get_buf(winnr)
     local ok, root_lang_tree = pcall(vim.treesitter.get_parser, buf)
-    if not ok then
+    if not ok or not root_lang_tree then
         return
     end
 


### PR DESCRIPTION
## Problem

In Neovim 0.12, `vim.treesitter.get_parser()` returns `nil` instead of throwing an error when no parser is available ([breaking change](https://neovim.io/doc/user/news-0.12/)).

All 5 call sites of `get_parser()` in this plugin wrap it in `pcall`, which catches errors but not `nil` returns:

```lua
local ok, parser = pcall(vim.treesitter.get_parser)
if not ok then
    return
end
parser:parse(true) -- parser is nil here → error
```

This causes `attempt to index local 'parser' (a nil value)` whenever the parser is unavailable at call time.

The most common reproduction is `rename_tag` — it is registered as a buffer-local `InsertLeave` autocmd, and fires when navigating away via Telescope or other pickers. The picker's prompt starts in insert mode, and when a file is selected, the new buffer opens and autotag attaches before insert mode ends, triggering `InsertLeave` with no parser ready.

## Fix

Add a nil check for the parser alongside the existing pcall error check at all 5 call sites:

```diff
- if not ok then
+ if not ok or not parser then
```

**Affected functions:**
- `internal.lua`: `rename_tag`, `close_tag`, `close_slash_tag`
- `utils.lua`: `is_react_file`, `get_ts_node`

This preserves backwards compatibility with Neovim 0.9.x/0.10.x where `get_parser()` still throws on failure.

## Test

1. Open Neovim 0.12+
2. Use Telescope (`<C-p>`) to search for and open a `.tsx` file
3. Verify no error occurs on entry
4. Open the `.tsx` file, edit a tag name in insert mode, and verify rename still works